### PR TITLE
Testnet launch adjustments

### DIFF
--- a/src/routes/liquidity-wallets.js
+++ b/src/routes/liquidity-wallets.js
@@ -79,16 +79,13 @@ router.get('/', getLiquidityWalletValidator, isRequired, async (req, res) => {
   if (validator.length) {
     return res.status(400).send(validator);
   }
-  const wallets = await collection
-    .find({ chainId: req.query.chainId, userId: res.locals.userId })
-    .toArray();
-  if (wallets.length !== 0) {
-    res.status(200).send(wallets);
-  } else {
-    res.status(404).send({
-      msg: 'No wallet found.',
-    });
-  }
+  res
+    .status(200)
+    .send(
+      await collection
+        .find({ chainId: req.query.chainId, userId: res.locals.userId })
+        .toArray()
+    );
 });
 
 /* This is a route that is used to get all the wallets for a specific chain. */
@@ -97,16 +94,9 @@ router.get('/all', isRequired, async (req, res) => {
   if (validator.length) {
     return res.status(400).send(validator);
   }
-  const wallets = await collection
-    .find({ userId: res.locals.userId })
-    .toArray();
-  if (wallets.length !== 0) {
-    res.status(200).send(wallets);
-  } else {
-    res.status(404).send({
-      msg: 'No wallet found.',
-    });
-  }
+  res
+    .status(200)
+    .send(await collection.find({ userId: res.locals.userId }).toArray());
 });
 
 /* This is a route that is used to get a single wallet. */
@@ -119,18 +109,13 @@ router.get(
     if (validator.length) {
       return res.status(400).send(validator);
     }
-    const wallet = await collection.findOne({
-      walletAddress: req.query.walletAddress,
-      chainId: req.query.chainId,
-      userId: res.locals.userId,
-    });
-    if (wallet) {
-      res.status(200).send(wallet);
-    } else {
-      res.status(404).send({
-        msg: 'No wallet found.',
-      });
-    }
+    res.status(200).send(
+      await collection.findOne({
+        walletAddress: req.query.walletAddress,
+        chainId: req.query.chainId,
+        userId: res.locals.userId,
+      })
+    );
   }
 );
 
@@ -140,17 +125,12 @@ router.get('/id/:id', getWalletByIdValidator, isRequired, async (req, res) => {
   if (validator.length) {
     return res.status(400).send(validator);
   }
-  const wallet = await collection.findOne({
-    _id: new ObjectId(req.params.id),
-    userId: res.locals.userId,
-  });
-  if (wallet) {
-    res.status(200).send(wallet);
-  } else {
-    res.status(404).send({
-      msg: 'No wallet found.',
-    });
-  }
+  res.status(200).send(
+    await collection.findOne({
+      _id: new ObjectId(req.params.id),
+      userId: res.locals.userId,
+    })
+  );
 });
 
 /* This is a route that is used to delete a wallet. */

--- a/src/routes/offers.js
+++ b/src/routes/offers.js
@@ -39,14 +39,7 @@ router.post('/', createOfferValidator, isRequired, async (req, res) => {
 
 /* This is a GET request that returns all offers. */
 router.get('/', isRequired, async (req, res) => {
-  let results = await collection.find({}).toArray();
-  if (results.length !== 0) {
-    res.send(results).status(200);
-  } else {
-    res.status(404).send({
-      msg: 'No offer found.',
-    });
-  }
+  res.send(await collection.find({}).toArray()).status(200);
 });
 
 /* This is a GET request that returns all offers for a specific user. */
@@ -66,17 +59,12 @@ router.get(
     if (validator.length) {
       return res.status(400).send(validator);
     }
-    const result = await collection.findOne({
-      offerId: req.query.offerId,
-      userId: res.locals.userId,
-    });
-    if (result) {
-      res.status(200).send(result);
-    } else {
-      res.status(404).send({
-        msg: 'No offer found',
-      });
-    }
+    res.status(200).send(
+      await collection.findOne({
+        offerId: req.query.offerId,
+        userId: res.locals.userId,
+      })
+    );
   }
 );
 
@@ -86,17 +74,12 @@ router.get('/id', getOfferByIdValidator, isRequired, async (req, res) => {
   if (validator.length) {
     return res.status(400).send(validator);
   }
-  const result = await collection.findOne({
-    _id: new ObjectId(req.query.id),
-    userId: res.locals.userId,
-  });
-  if (result) {
-    res.status(200).send(result);
-  } else {
-    res.status(404).send({
-      msg: 'No offer found',
-    });
-  }
+  res.status(200).send(
+    await collection.findOne({
+      _id: new ObjectId(req.query.id),
+      userId: res.locals.userId,
+    })
+  );
 });
 
 /* This is a DELETE request that deletes an offer by id. */

--- a/src/routes/trades.js
+++ b/src/routes/trades.js
@@ -38,14 +38,9 @@ router.post('/', createTradeValidator, isRequired, async (req, res) => {
 
 /* This is a GET request that returns all trades for a specific user. */
 router.get('/user', isRequired, async (req, res) => {
-  let results = await collection.find({ userId: res.locals.userId }).toArray();
-  if (results.length !== 0) {
-    res.send(results).status(200);
-  } else {
-    res.status(404).send({
-      msg: 'No trade found.',
-    });
-  }
+  res
+    .send(await collection.find({ userId: res.locals.userId }).toArray())
+    .status(200);
 });
 
 /* This is a GET request that returns a trade for a specific user by the trade id. */
@@ -54,33 +49,27 @@ router.get(
   getTradeByTradeIdValidator,
   isRequired,
   async (req, res) => {
-    const result = await collection.findOne({
-      userId: res.locals.userId,
-      tradeId: req.query.tradeId,
-    });
-    if (result) {
-      res.send(result).status(200);
-    } else {
-      res.status(404).send({
-        msg: 'No trade found.',
-      });
-    }
+    res
+      .send(
+        await collection.findOne({
+          userId: res.locals.userId,
+          tradeId: req.query.tradeId,
+        })
+      )
+      .status(200);
   }
 );
 
 /* This is a GET request that returns a trade for a specific user by the trade id. */
 router.get('/id', getTradeByIdValidator, isRequired, async (req, res) => {
-  const result = await collection.findOne({
-    userId: res.locals.userId,
-    _id: new ObjectId(req.query.id),
-  });
-  if (result) {
-    res.send(result).status(200);
-  } else {
-    res.status(404).send({
-      msg: 'No trade found',
-    });
-  }
+  res
+    .send(
+      await collection.findOne({
+        userId: res.locals.userId,
+        _id: new ObjectId(req.query.id),
+      })
+    )
+    .status(200);
 });
 
 /* This is a PUT request that adds a trade to an offer. */

--- a/src/validators/offers.validator.js
+++ b/src/validators/offers.validator.js
@@ -31,6 +31,11 @@ export const createOfferValidator = [
     .withMessage('must be string value')
     .notEmpty()
     .withMessage('must not be empty'),
+  body('hash')
+    .isString()
+    .withMessage('must be string value')
+    .notEmpty()
+    .withMessage('must not be empty'),
   body('offerId')
     .isString()
     .withMessage('must be string value')

--- a/src/validators/offers.validator.js
+++ b/src/validators/offers.validator.js
@@ -71,36 +71,3 @@ export const deleteOfferValidator = [
 export const updateOfferValidator = [
   body('offerId').notEmpty().withMessage('must not be empty'),
 ];
-
-export const addTradeOfferValidator = [
-  body('amountGRT')
-    .isString()
-    .withMessage('must be string value')
-    .notEmpty()
-    .withMessage('should not be empty'),
-  body('offerId')
-    .isString()
-    .withMessage('must be string value')
-    .notEmpty()
-    .withMessage('should not be empty'),
-  body('destAddr')
-    .isString()
-    .withMessage('must be string value')
-    .notEmpty()
-    .withMessage('should not be empty'),
-  body('user')
-    .isString()
-    .withMessage('must be string value')
-    .notEmpty()
-    .withMessage('should not be empty'),
-  body('amountToken')
-    .isString()
-    .withMessage('must be string value')
-    .notEmpty()
-    .withMessage('should not be empty'),
-  body('tradeId')
-    .isString()
-    .withMessage('must be string value')
-    .notEmpty()
-    .withMessage('should not be empty'),
-];

--- a/src/validators/trades.validator.js
+++ b/src/validators/trades.validator.js
@@ -6,7 +6,17 @@ export const createTradeValidator = [
     .withMessage('must be string value')
     .notEmpty()
     .withMessage('must not be empty'),
-  body('amountGRT')
+  body('amountTokenDeposit')
+    .isString()
+    .withMessage('must be string value')
+    .notEmpty()
+    .withMessage('must not be empty'),
+  body('addressTokenDeposit')
+    .isString()
+    .withMessage('must be string value')
+    .notEmpty()
+    .withMessage('must not be empty'),
+  body('chainIdTokenDeposit')
     .isString()
     .withMessage('must be string value')
     .notEmpty()
@@ -16,7 +26,7 @@ export const createTradeValidator = [
     .withMessage('must be string value')
     .notEmpty()
     .withMessage('must not be empty'),
-  body('amountToken')
+  body('amountTokenOffer')
     .isString()
     .withMessage('must be string value')
     .notEmpty()


### PR DESCRIPTION
# Description of the changes

## No changes for the following collections/routes:
- `Tokens`
- `Blockchains`
- `Admins`
- `Staking`: unused for the moment, just kept as is. 

## Changes for `trades` collection/route
`trades` collection (the one dedicated for the moment when userA makes the deposit and accept an offer), to be as generic as possible, I propose the following changes:

### `POST` method
In the `POST` method, adding the following fields to uniquely identify the token deposited by userA (for the moment we will only accept Goerli-ETH but even when this will evolve, this will be fully compatible):

- `amountTokenDeposit`
- `addressTokenDeposit` 
- `chainIdTokenDeposit`

And hence modify the naming `amountToken` to `amountTokenOffer` to avoid confusion because it concerns the amount of tokens that userB must pay now to userA according to his offer and the exchange rate of the moment.

### `GET` methods

For all the `GET` methods, if no trades are found I modified to just return an empty result and not an error because as mentioned by @milukove last week, if there is no result this is not an error but just an empty result.

## Changes for `offers` collection/route
I saw that the `hash` is present as a field, I imagine this is the `hash` of the transaction corresponding to the creation of the offer. I then add this parameter in the `createOfferValidator` space.

- For all the `GET` methods: empty result if no offer but no error
- `addTradeOfferValidator` was unused, so I removed it


## Changes for `Liquidity-wallets` collection/route
- For all the `GET` methods: empty result if no offer but no error