### PR TITLE
feat: adding endpoint to get master contract address

### DIFF
--- a/src/routes/view-blockchains.js
+++ b/src/routes/view-blockchains.js
@@ -76,4 +76,48 @@ router.get(
   }
 );
 
+router.post('/master-contract-address', isRequired, async (req, res) => {
+  const db = await Database.getInstance(req);
+  const collection = db.collection('blockchains');
+
+  const blockchain = await collection.findOne({
+    caipId: req.body.params?.fieldData?._grinderyChain,
+  });
+
+  if (!blockchain) {
+    res.status(404).send({
+      msg: 'This blockchain doesnt exist.',
+    });
+  }
+
+  if (
+    !blockchain.usefulAddresses ||
+    !blockchain.usefulAddresses.grtPoolAddress
+  ) {
+    res.status(404).send({
+      msg: 'Master contract address is not found for the required blockchain.',
+    });
+  }
+
+  res.status(200).send({
+    inputFields: [
+      {
+        key: '_grinderyChain',
+        required: true,
+        type: 'string',
+        label: 'Blockchain',
+      },
+      {
+        key: '_mercariMasterContractAddress',
+        label: 'Mercari master contract address',
+        type: 'string',
+        required: true,
+        placeholder: 'Mercari master contract address',
+        computed: true,
+        default: blockchain.usefulAddresses.grtPoolAddress,
+      },
+    ],
+  });
+});
+
 export default router;

--- a/src/test/utils/variables.js
+++ b/src/test/utils/variables.js
@@ -17,6 +17,10 @@ export const notAMongoDBId = 'notAMongoDBId';
 // Admins paths
 export const pathAdmin_Get_IsAdmin = '/unit-test/admins';
 
+// View Blockchains paths
+export const pathBlockchains_Get_MasterContractAddress =
+  '/unit-test/view-blockchains/master-contract-address';
+
 // Blockchains paths
 export const pathBlockchains_Post_NewBlockchain = '/unit-test/blockchains';
 export const pathBlockchains_Get_MongoDBId = '/unit-test/blockchains/';

--- a/src/test/view-blockchains.test.js
+++ b/src/test/view-blockchains.test.js
@@ -1,0 +1,71 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index.js';
+import { mockedToken } from './utils/utils.js';
+import {
+  collectionBlockchains,
+  mockBlockchain,
+  pathBlockchains_Get_MasterContractAddress,
+} from './utils/variables.js';
+
+/* eslint-disable no-unused-expressions */
+
+chai.use(chaiHttp);
+
+const nexusCallInputProviderReq = {
+  params: {
+    fieldData: { _grinderyChain: 'eip155:534' },
+  },
+};
+
+describe('View blockchains route', async function () {
+  describe('GET master smart contract address', async function () {
+    beforeEach(async function () {
+      await collectionBlockchains.insertMany([
+        {
+          ...mockBlockchain,
+          usefulAddresses: {
+            grtPoolAddress: 'myGrtPoolAddress',
+          },
+        },
+      ]);
+    });
+
+    it('Should return 403 if no token is provided', async function () {
+      const res = await chai
+        .request(app)
+        .post(pathBlockchains_Get_MasterContractAddress)
+        .send(nexusCallInputProviderReq);
+      chai.expect(res).to.have.status(403);
+    });
+
+    it('Should return the master contract address', async function () {
+      const res = await chai
+        .request(app)
+        .post(pathBlockchains_Get_MasterContractAddress)
+        .set('Authorization', `Bearer ${mockedToken}`)
+        .send(nexusCallInputProviderReq);
+
+      chai.expect(res).to.have.status(200);
+      chai.expect(res.body).to.deep.equal({
+        inputFields: [
+          {
+            key: '_grinderyChain',
+            required: true,
+            type: 'string',
+            label: 'Blockchain',
+          },
+          {
+            key: '_mercariMasterContractAddress',
+            label: 'Mercari master contract address',
+            type: 'string',
+            required: true,
+            placeholder: 'Mercari master contract address',
+            computed: true,
+            default: 'myGrtPoolAddress',
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR aims to create an endpoint to obtain the address of the master contract for each blockchain available in our Mercari database. To this end, a POST route is created.